### PR TITLE
upgrade ocaml-5.1.1

### DIFF
--- a/.github/actions/init_opam/action.yml
+++ b/.github/actions/init_opam/action.yml
@@ -4,13 +4,9 @@ description: |
 runs:
   using: composite
   steps:
-  - name: Set-up OCaml
-    uses: ocaml/setup-ocaml@v2
-    with:
-      ocaml-compiler: 5.1
   - name: Init opam
     run: |-
-      opam init --compiler=5.1.0 --disable-sandboxing -y
+      opam init --compiler=5.1.1 --disable-sandboxing -y
       opam install menhir ppxlib -y
     shell: bash
   - name: OCaml Configuration Info

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,7 @@
 name: Build and test
 on:
   push:
-    branches:
-    - main
+  pull_request:
 jobs:
   linux-build-and-test:
     runs-on: 4-core-ubuntu


### PR DESCRIPTION
we seem to have hit a known 5.1.0 ocaml compiler bug affecting ocamlopt linked executables (missing zstd symbols). see the [ocaml-5.1.1 release notes](https://ocaml.org/releases/5.1.1) for more details. 